### PR TITLE
fix: specify UTF-8 encoding when reading style files

### DIFF
--- a/nodes/core/predefined_styles.py
+++ b/nodes/core/predefined_styles.py
@@ -69,7 +69,7 @@ class StyleLibrary:
             category = name_parts[2].strip()
             if version and category:
                 num_loaded_files  += 1
-                num_loaded_styles += self.load_from_string(file_path.read_text(),
+                num_loaded_styles += self.load_from_string(file_path.read_text(encoding='utf-8'),
                                                            category = category,
                                                            version  = version)
         return num_loaded_files, num_loaded_styles


### PR DESCRIPTION
## Summary

- `file_path.read_text()` in `nodes/core/predefined_styles.py` was called without an explicit encoding
- On Windows the default encoding is `cp1252`, which cannot decode UTF-8 byte sequences present in the bundled style `.txt` files
- This caused a `UnicodeDecodeError` at ComfyUI startup, preventing the node from loading entirely

**Fix:** add `encoding='utf-8'` to the `read_text()` call — a single-character change with no behaviour difference on Linux/macOS (where UTF-8 is already the default).

## Reproduction

Start ComfyUI on a Windows machine with a non-UTF-8 system locale. The node fails to import with:
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 6737: character maps to <undefined>
```

## Test plan

- [x] Launch ComfyUI on Windows — node loads without error
- [x] Style files load and populate the style selector as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)