### PR TITLE
Feature: Added final Sigma output for use with Nvidia PID Decode.

### DIFF
--- a/nodes/core/zsampler_turbo_core.py
+++ b/nodes/core/zsampler_turbo_core.py
@@ -509,6 +509,12 @@ def execute_3_stage_denoising(comfy_latent: ComfyLatent,
                         progress_preview = ProgressPreview( 100,
                             parent=(progress_preview, 100*prog3//total, 100*total//total)),
                         )
+    _pid_sigmas = (sigmas3 if sigmas3 is not None else
+                   sigmas2 if sigmas2 is not None else
+                   sigmas1)
+    if _pid_sigmas is not None and _pid_sigmas.numel() >= 2:
+        comfy_latent["pid_sigma"] = float(_pid_sigmas[-2].item())
+
     return comfy_latent
 
 

--- a/nodes/empty_zimage_latent_image.py
+++ b/nodes/empty_zimage_latent_image.py
@@ -83,6 +83,10 @@ class EmptyZImageLatentImage(io.ComfyNode):
             ],
             outputs=[
                 io.Latent.Output(tooltip="An empty latent image generated according to the given parameters."),
+                io.Int.Output(display_name="width",
+                              tooltip="Actual pixel width after snapping to the 32-pixel grid."),
+                io.Int.Output(display_name="height",
+                              tooltip="Actual pixel height after snapping to the 32-pixel grid."),
             ]
         )
 
@@ -110,7 +114,7 @@ class EmptyZImageLatentImage(io.ComfyNode):
 
         # create the latent image as a tensor of zeros
         latent = torch.zeros( (batch_size, LATENT_CHANNELS, latent_height, latent_width), device=latent_device )
-        return io.NodeOutput({"samples":latent})
+        return io.NodeOutput({"samples": latent}, image_width, image_height)
 
 
     #__ internal functions ________________________________

--- a/nodes/zsampler_turbo_2.py
+++ b/nodes/zsampler_turbo_2.py
@@ -131,12 +131,12 @@ class ZSamplerTurbo2(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
-            io.Float.Output(display_name="pid_sigma",
-                            tooltip="The input sigma of the final denoising step. "
-                                    "Connect to Merserk PiD Decode's sigma socket for a "
-                                    "direct latent-to-image PiD decode. Also embedded in "
-                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
-                           ),
+                io.Float.Output(display_name="pid_sigma",
+                                 tooltip="The input sigma of the final denoising step. "
+                                        "Connect to Merserk PiD Decode's sigma socket for a "
+                                        "direct latent-to-image PiD decode. Also embedded in "
+                                        "the latent dict as 'pid_sigma' for auto-passthrough. "
+                                ),
             ]
         )
 

--- a/nodes/zsampler_turbo_2.py
+++ b/nodes/zsampler_turbo_2.py
@@ -131,6 +131,12 @@ class ZSamplerTurbo2(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
+            io.Float.Output(display_name="pid_sigma",
+                            tooltip="The input sigma of the final denoising step. "
+                                    "Connect to Merserk PiD Decode's sigma socket for a "
+                                    "direct latent-to-image PiD decode. Also embedded in "
+                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
+                           ),
             ]
         )
 
@@ -210,4 +216,5 @@ class ZSamplerTurbo2(io.ComfyNode):
                                             progress_preview = ProgressPreview.from_model( model ),
                                             )
 
-        return io.NodeOutput(latent_output)
+        pid_sigma = latent_output.get("pid_sigma", 0.0)
+        return io.NodeOutput(latent_output, pid_sigma)

--- a/nodes/zsampler_turbo_2_advanced.py
+++ b/nodes/zsampler_turbo_2_advanced.py
@@ -148,13 +148,13 @@ class ZSamplerTurbo2Advanced(io.ComfyNode):
                 io.Latent.Output(display_name="latent_output",
                                  tooltip="The resulting denoised latent image, ready to be decoded "
                                          "by a VAE or passed to another node for further processing. ",
-                                )
-            io.Float.Output(display_name="pid_sigma",
-                            tooltip="The input sigma of the final denoising step. "
-                                    "Connect to Merserk PiD Decode's sigma socket for a "
-                                    "direct latent-to-image PiD decode. Also embedded in "
-                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
-                           ),
+                                ),
+                io.Float.Output(display_name="pid_sigma",
+                                 tooltip="The input sigma of the final denoising step. "
+                                        "Connect to Merserk PiD Decode's sigma socket for a "
+                                        "direct latent-to-image PiD decode. Also embedded in "
+                                        "the latent dict as 'pid_sigma' for auto-passthrough. "
+                                ),
             ]
         )
 

--- a/nodes/zsampler_turbo_2_advanced.py
+++ b/nodes/zsampler_turbo_2_advanced.py
@@ -149,6 +149,12 @@ class ZSamplerTurbo2Advanced(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready to be decoded "
                                          "by a VAE or passed to another node for further processing. ",
                                 )
+            io.Float.Output(display_name="pid_sigma",
+                            tooltip="The input sigma of the final denoising step. "
+                                    "Connect to Merserk PiD Decode's sigma socket for a "
+                                    "direct latent-to-image PiD decode. Also embedded in "
+                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
+                           ),
             ]
         )
 
@@ -223,5 +229,6 @@ class ZSamplerTurbo2Advanced(io.ComfyNode):
                                             progress_preview = ProgressPreview.from_model( model ),
                                             )
 
-        return io.NodeOutput(latent_output)
+        pid_sigma = latent_output.get("pid_sigma", 0.0)
+        return io.NodeOutput(latent_output, pid_sigma)
 

--- a/nodes/zsampler_turbo_2_simple.py
+++ b/nodes/zsampler_turbo_2_simple.py
@@ -119,6 +119,12 @@ class ZSamplerTurbo2Simple(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
+                                            io.Float.Output(display_name="pid_sigma",
+                            tooltip="The input sigma of the final denoising step. "
+                                    "Connect to Merserk PiD Decode's sigma socket for a "
+                                    "direct latent-to-image PiD decode. Also embedded in "
+                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
+                           ),
             ]
         )
 
@@ -207,4 +213,5 @@ class ZSamplerTurbo2Simple(io.ComfyNode):
             progress_preview = ProgressPreview.from_model(model),
         )
 
-        return io.NodeOutput(latent_output)
+        pid_sigma = latent_output.get("pid_sigma", 0.0)
+        return io.NodeOutput(latent_output, pid_sigma)

--- a/nodes/zsampler_turbo_2_simple.py
+++ b/nodes/zsampler_turbo_2_simple.py
@@ -119,12 +119,12 @@ class ZSamplerTurbo2Simple(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
-                                            io.Float.Output(display_name="pid_sigma",
-                            tooltip="The input sigma of the final denoising step. "
-                                    "Connect to Merserk PiD Decode's sigma socket for a "
-                                    "direct latent-to-image PiD decode. Also embedded in "
-                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
-                           ),
+                io.Float.Output(display_name="pid_sigma",
+                                 tooltip="The input sigma of the final denoising step. "
+                                        "Connect to Merserk PiD Decode's sigma socket for a "
+                                        "direct latent-to-image PiD decode. Also embedded in "
+                                        "the latent dict as 'pid_sigma' for auto-passthrough. "
+                                ),
             ]
         )
 

--- a/nodes/zsampler_turbo_X21.py
+++ b/nodes/zsampler_turbo_X21.py
@@ -130,12 +130,12 @@ class ZSamplerTurboX21(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
-            io.Float.Output(display_name="pid_sigma",
-                            tooltip="The input sigma of the final denoising step. "
-                                    "Connect to Merserk PiD Decode's sigma socket for a "
-                                    "direct latent-to-image PiD decode. Also embedded in "
-                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
-                           ),
+                io.Float.Output(display_name="pid_sigma",
+                                 tooltip="The input sigma of the final denoising step. "
+                                        "Connect to Merserk PiD Decode's sigma socket for a "
+                                        "direct latent-to-image PiD decode. Also embedded in "
+                                        "the latent dict as 'pid_sigma' for auto-passthrough. "
+                               ),
             ]
         )
 

--- a/nodes/zsampler_turbo_X21.py
+++ b/nodes/zsampler_turbo_X21.py
@@ -130,6 +130,12 @@ class ZSamplerTurboX21(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
+            io.Float.Output(display_name="pid_sigma",
+                            tooltip="The input sigma of the final denoising step. "
+                                    "Connect to Merserk PiD Decode's sigma socket for a "
+                                    "direct latent-to-image PiD decode. Also embedded in "
+                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
+                           ),
             ]
         )
 
@@ -223,8 +229,8 @@ class ZSamplerTurboX21(io.ComfyNode):
             samplers                 = (*samplers,),
             progress_preview = ProgressPreview.from_model(model),
         )
-
-        return io.NodeOutput(latent_output)
+        pid_sigma = latent_output.get("pid_sigma", 0.0)
+        return io.NodeOutput(latent_output, pid_sigma)
 
 
     #__ internal functions ________________________________

--- a/nodes/zsampler_turbo_X21_advanced.py
+++ b/nodes/zsampler_turbo_X21_advanced.py
@@ -147,6 +147,12 @@ class ZSamplerTurboX21Advanced(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
+            io.Float.Output(display_name="pid_sigma",
+                            tooltip="The input sigma of the final denoising step. "
+                                    "Connect to Merserk PiD Decode's sigma socket for a "
+                                    "direct latent-to-image PiD decode. Also embedded in "
+                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
+                           ),
             ]
         )
 
@@ -253,5 +259,5 @@ class ZSamplerTurboX21Advanced(io.ComfyNode):
             samplers                  = (*samplers,),
             progress_preview = ProgressPreview.from_model(model),
         )
-
-        return io.NodeOutput(latent_output)
+        pid_sigma = latent_output.get("pid_sigma", 0.0)
+        return io.NodeOutput(latent_output, pid_sigma)

--- a/nodes/zsampler_turbo_X21_advanced.py
+++ b/nodes/zsampler_turbo_X21_advanced.py
@@ -147,12 +147,12 @@ class ZSamplerTurboX21Advanced(io.ComfyNode):
                                  tooltip="The resulting denoised latent image, ready for decoding "
                                          "by a VAE or passed to another node for further processing. "
                                 ),
-            io.Float.Output(display_name="pid_sigma",
-                            tooltip="The input sigma of the final denoising step. "
-                                    "Connect to Merserk PiD Decode's sigma socket for a "
-                                    "direct latent-to-image PiD decode. Also embedded in "
-                                    "the latent dict as 'pid_sigma' for auto-passthrough. "
-                           ),
+                io.Float.Output(display_name="pid_sigma",
+                                 tooltip="The input sigma of the final denoising step. "
+                                        "Connect to Merserk PiD Decode's sigma socket for a "
+                                        "direct latent-to-image PiD decode. Also embedded in "
+                                        "the latent dict as 'pid_sigma' for auto-passthrough. "
+                                ),
             ]
         )
 


### PR DESCRIPTION
I made two changes:

1) Expose Sigma for use with PID Decode.
Add pid_sigma output to all five ZSamplerTurbo variants for Merserk PiD Decode

Exposes the input sigma of the final denoising step from all five
ZSamplerTurbo node variants for direct compatibility with
Merserk/ComfyUI-PiD's PiD Decode node.

Files changed:
- nodes/core/zsampler_turbo_core.py: embeds pid_sigma into the
  returned latent dict (sigmas[-2] of last active stage)
- nodes/zsampler_turbo_2.py: adds Float output socket
- nodes/zsampler_turbo_2_advanced.py: adds Float output socket
- nodes/zsampler_turbo_2_simple.py: adds Float output socket
- nodes/zsampler_turbo_X21.py: adds Float output socket
- nodes/zsampler_turbo_X21_advanced.py: adds Float output socket

Note: ZSamplerTurbo2Simple with old_scheduler=True uses the 'alpha'
sigma preset (same as X21). The pid_sigma value correctly reflects
whichever preset was active at generation time.

Two integration paths: wire the Float output explicitly to PiD
Decode's sigma socket, or leave sigma at 0.0 for auto-passthrough
via latent['pid_sigma']. No breaking changes.

2) Add width and height INT outputs to EmptyZImageLatentImage

Exposes the actual computed pixel dimensions (after 32px grid snapping)
as live INT output sockets. Resolution depends on ratio, size, and
orientation together so cannot be shown in static combo labels.

Width and height can be wired to Show Text nodes for workflow
inspection, or to downstream nodes that accept pixel dimensions.
No breaking changes - size label strings are unchanged.