### PR TITLE
fix: handle ComfyUI's new list-based --verbose in setup_logger (IMPORT FAILED on 0.29.0)

### DIFF
--- a/nodes/core/system.py
+++ b/nodes/core/system.py
@@ -45,12 +45,39 @@ class _CustomFormatter(logging.Formatter):
 
 logger: logging.Logger = logging.getLogger()
 
+def _coerce_log_level(log_level):
+    """Normalize a log level that may arrive in ComfyUI's newer `--verbose` format.
+
+    ComfyUI changed `--verbose` to `action=VerboseAction, nargs='*', default=[]`,
+    so `args.verbose` is now a list of (LEVEL, file) tuples instead of a plain
+    level string. Passing that list straight to Logger.setLevel() raises
+    TypeError. Older ComfyUI still passes a string, so both are accepted here.
+    """
+    if isinstance(log_level, (int, str)) and log_level != "":
+        return log_level
+
+    if isinstance(log_level, (list, tuple)):
+        # ComfyUI's own helper picks the most verbose console level, else 'INFO'
+        try:
+            from comfy.cli_args import get_console_log_level
+            return get_console_log_level(log_level)
+        except Exception:
+            levels = [entry[0] if isinstance(entry, (list, tuple)) else entry
+                      for entry in log_level]
+            for level in levels:
+                if isinstance(level, (int, str)):
+                    return level
+
+    return "INFO"
+
+
 def setup_logger(name      : str,
                  emoji     : str,
                  log_level : str  = "INFO",
                  use_stdout: bool = False
                  ):
     global logger
+    log_level = _coerce_log_level(log_level)
     if logger is not None:
         logger.warning("Logger already set up. Skipping setup_logger().")
 


### PR DESCRIPTION
Fixes #18 (and the same root cause reported in #11 / #14).

## The bug

ComfyUI 0.29.0 changed `--verbose` in `comfy/cli_args.py`:

```python
parser.add_argument("--verbose", action=VerboseAction, nargs='*', default=[],
                    metavar='LEVEL FILE', help='...May be repeated.')
```

`args.verbose` is therefore no longer a level string — it is a **list of `(LEVEL, file)` tuples**, empty by default. `__init__.py:53` passes it straight through:

```python
setup_logger(log_level=args.verbose, emoji=__PROJECT_EMOJI, name="ZI_POWER", use_stdout=args.log_stdout)
```

…and `setup_logger()` hands it to `Logger.setLevel()`:

```
TypeError: Level not an integer or a valid string: []
[WARNING] Cannot import ...\custom_nodes\ComfyUI-ZImagePowerNodes module for custom nodes
```

The whole pack fails to import on any ComfyUI ≥ 0.29.0 that isn't run with `--verbose`.

## Why not the snippet from #18

The workaround circulating in the issue thread normalizes with `log_level[0]`:

```python
if isinstance(log_level, list):
    log_level = log_level[0] if log_level else "INFO"
```

That fixes the empty case but assumes the list holds strings. `VerboseAction.__call__` actually appends **tuples** (`output = ('DEBUG', None)`), so the moment someone does pass `--verbose`, the identical `TypeError` returns. Measured against the real parser:

```
argv=[]                       -> args.verbose = []
argv=['--verbose']            -> args.verbose = [('DEBUG', None)]
argv=['--verbose', 'DEBUG']   -> args.verbose = [('DEBUG', None)]
argv=['--verbose', 'WARNING'] -> args.verbose = [('WARNING', None)]

snippet([])                    -> 'INFO'            setLevel OK
snippet(['--verbose'])         -> ('DEBUG', None)   !! TypeError: Level not an integer or a valid string
snippet(['--verbose','DEBUG']) -> ('DEBUG', None)   !! TypeError
```

## This change

Adds `_coerce_log_level()` and calls it at the top of `setup_logger()` — normalizing where the contract lives, so every caller benefits rather than patching the one call site.

For the list form it delegates to ComfyUI's own `get_console_log_level()`, which already encodes the intended semantics (pick the most verbose *console* entry; ignore file-only outputs; default `INFO`). A manual fallback covers the case where that helper isn't importable, and strings/ints pass through untouched so older ComfyUI keeps working.

## Verification

Every shape `VerboseAction` can emit, each fed to a real `Logger.setLevel()`:

```
[]  (no --verbose: the reported crash)     -> 'INFO'      setLevel OK
--verbose              -> [(DEBUG,None)]   -> 'DEBUG'     setLevel OK
--verbose WARNING      -> [(WARNING,None)] -> 'WARNING'   setLevel OK
--verbose DEBUG f.log  -> file only        -> 'INFO'      setLevel OK
mixed console+file                         -> 'ERROR'     setLevel OK
legacy string 'INFO' / 'DEBUG'             -> passthrough setLevel OK
int logging.DEBUG (20)                     -> passthrough setLevel OK
None                                       -> 'INFO'      setLevel OK
```

Note `--verbose DEBUG f.log` correctly leaves the console at `INFO` rather than forcing `DEBUG`, matching ComfyUI's own behaviour for file-only outputs.

Loaded end-to-end in a live install (ComfyUI `v0.29.0-33-ge803f24e`, Python 3.13.11, Windows):

```
[⚡ZI_POWER INFO] Version: 2.0.0
[⚡ZI_POWER INFO] This package includes 20 active nodes and 7 deprecated ones.
comfy_entrypoint OK -> 27 node classes
```

No behaviour change on ComfyUI versions that still pass a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qH5duZDQGKJcy5U9CCARw
